### PR TITLE
Improves the appearance of NEXUS character sets.

### DIFF
--- a/dendropy/dataio/nexuswriter.py
+++ b/dendropy/dataio/nexuswriter.py
@@ -397,7 +397,8 @@ class NexusWriter(iosys.DataWriter):
                 label = textutils.escape_nexus_token(char_set.label,
                         preserve_spaces=self.preserve_spaces,
                         quote_underscores=not self.unquoted_underscores)
-                pos = " ".join(str(c+1) for c in char_set.character_indices)
+                ranges = textutils.group_ranges(char_set.character_indices)
+                pos = " ".join("-".join(str(c+1) for c in r) for r in ranges)
                 nexus.append('    charset %s = %s;\n' % (label, pos))
             nexus.append('END;\n\n')
         stream.write('\n'.join(nexus))

--- a/dendropy/utility/textutils.py
+++ b/dendropy/utility/textutils.py
@@ -23,6 +23,7 @@ Various text-manipulating and formatting utilities.
 import re
 import sys
 import time
+import itertools
 
 ###############################################################################
 ## NEWICK/NEXUS format support. Placed here instead of `nexustokenizer` so that
@@ -68,6 +69,19 @@ def split_as_newick_string(split, taxon_set, preserve_spaces=False, quote_unders
         split = split >> 1
     assert ( len(left) + len(right) ) == len(taxlabels)
     return "((%s), (%s))" % (", ".join(left), ", ".join(right))
+
+def group_ranges(L):
+    """
+    Collapses a list of integers into a list of the start and end of
+    consecutive runs of numbers. Returns a generator of generators.
+
+    >>> [list(x) for x in group_ranges([1, 2, 3, 5, 6, 8])]
+    [[1, 3], [5, 6], [8]]
+    """
+    for w, z in itertools.groupby(L, lambda x, y=itertools.count(): next(y)-x):
+        grouped = list(z)
+        yield (x for x in [grouped[0], grouped[-1]][:len(grouped)])
+
 
 ###############################################################################
 ## Allows string objects to be annotated/decorated with attributes.


### PR DESCRIPTION
Character partitions produced by DendroPy typically look something like this:

```
charset locus000 = 1 2 3 4 5 6;
charset locus001 = 7 8 9 10;
```

This patch collapses consecutive numbers into a range like so:

```
charset locus000 = 1-6;
charset locus001 = 7-10;
```

The result is a smaller written file and a more human-readable output. 
