### PR TITLE
Added missing "check_ultrametricity_prec" parameter

### DIFF
--- a/dendropy/coalescent.py
+++ b/dendropy/coalescent.py
@@ -327,7 +327,7 @@ def log_probability_of_coalescent_tree(tree, haploid_pop_size, check_ultrametric
     """
     Wraps up extraction of coalescent frames and reporting of probability.
     """
-    return log_probability_of_coalescent_frames(extract_coalescent_frames(tree),
+    return log_probability_of_coalescent_frames(extract_coalescent_frames(tree, check_ultrametricity_prec),
             haploid_pop_size)
 
 if de_hoon_statistics:


### PR DESCRIPTION
I made some UPGMA trees in R, using the 'phangorn' library, but they weren't passing with the default precision settings when I ran _dendropy.coalescent.log_probability_of_coalescent_tree_. After checking the source, it turns out that _dendropy.coalescent.log_probability_of_coalescent_tree_ wasn't passing the 'check_ultrametricity_prec' variable to 'log_probability_of_coalescent_frames'. I've fixed this in this admittedly very minor pull request. I hope this was helpful.

I ran nosetest with the truncated results below.
# 
## ERROR: testTreeListRoundTrip (dendropy.test.test_ape.DataRoundTrip)

Traceback (most recent call last):
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/test/test_ape.py", line 53, in testTreeListRoundTrip
    rt = ape.as_dendropy_object(ape_t, taxon_set=self.trees.taxon_set)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/interop/ape.py", line 95, in as_dendropy_object
    return dendropy.TreeList.get_from_path(f.name, "nexus", taxon_set=taxon_set)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/utility/iosys.py", line 236, in get_from_path
    **kwargs)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/dataobject/tree.py", line 57, in _parse_from_stream
    *_kwargs)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/dataobject/tree.py", line 206, in read
    d = DataSet(stream=stream, schema=schema, *_kwargs)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/dataobject/dataset.py", line 88, in __init__
    self.process_source_kwargs(**kwargs)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/utility/iosys.py", line 285, in process_source_kwargs
    self.read(stream=stream, schema=schema, **kwargs)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/dataobject/dataset.py", line 165, in read
    raise x
DataParseError: Error parsing data source "/var/folders/rv/gbz4r1394hj26hlwclx479vw0000gn/T/tmph1DG_l" on line 80 at column 9: Expecting '=' in definition of Tree '=' but found '('
# 
## ERROR: populate_test (dendropy.test.test_paup.PaupWrapperSplitsParse)

TypeError: populate_test() takes exactly 4 arguments (1 given)
# 
## ERROR: populate_test (dendropy.test.test_paup.PaupWrapperSplitsParseTest1)

TypeError: populate_test() takes exactly 4 arguments (1 given)
# 
## ERROR: dendropy.test.test_scm.is_test_enabled

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(_self.arg)
  File "/usr/local/lib/python2.7/site-packages/nose/util.py", line 613, in newfunc
    return func(_arg, **kw)
TypeError: is_test_enabled() takes at least 1 argument (0 given)
# 
## FAIL: testBirthDeathExt (dendropy.test.test_ape.ApeFunctions)

Traceback (most recent call last):
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/test/test_ape.py", line 103, in testBirthDeathExt
    self.assertAlmostEqual(v, bd[k], 3)
AssertionError: 0.2866789 != 0.2765149 within 3 places
# 
## FAIL: testDnaRoundTrip (dendropy.test.test_ape.DataRoundTrip)

Traceback (most recent call last):
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/test/test_ape.py", line 60, in testDnaRoundTrip
    self.assertDistinctButEqual(self.dna_chars, dp_c, distinct_taxa=False)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/test/support/datatest.py", line 94, in assertDistinctButEqual
    self.assertDistinctButEqualCharMatrix(data_object1, data_object2, *_kwargs)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/test/support/datatest.py", line 475, in assertDistinctButEqualCharMatrix
    self.assertDistinctButEqualDiscreteCharMatrix(char_matrix1, char_matrix2, *_kwargs)
  File "/Users/ngcrawford/Desktop/Code/DendroPy/dendropy/test/support/datatest.py", line 420, in assertDistinctButEqualDiscreteCharMatrix
    repr(char_matrix1), char_matrix2.character_types))
AssertionError: Unequal character type lists:

<dendropy.dataobject.char.DnaCharacterMatrix object at 0x10b48f6d0>: [<dendropy.dataobject.char.CharacterType object at 0x10b48f710>]

<dendropy.dataobject.char.DnaCharacterMatrix object at 0x10b48f6d0>: []

-------------------- >> begin captured logging << --------------------
DataRoundTrip: INFO: Comparing DiscreteCharacterMatrix objects 4484298448 and 4503333456
--------------------- >> end captured logging << ---------------------

---

Ran 391 tests in 467.054s

FAILED (errors=4, failures=2)
