### PR TITLE
closing temp files made by tempfile.mkstemp

### DIFF
--- a/dendropy/interop/paup.py
+++ b/dendropy/interop/paup.py
@@ -502,6 +502,7 @@ else:
                                         stdout=subprocess.PIPE)
             stdout, stderr = paup_run.communicate(paup_block)
             t = dendropy.Tree.get_from_path(output_tree_filepath, "nexus", taxon_set=char_matrix.taxon_set)
+            os.close(output_tree_file_handle)
             return t
 
     def estimate_tree(char_matrix,
@@ -571,6 +572,7 @@ else:
                                     stdout=subprocess.PIPE)
         stdout, stderr = paup_run.communicate(paup_template % paup_args)
         t = dendropy.Tree.get_from_path(output_tree_filepath, "nexus", taxon_set=char_matrix.taxon_set)
+        os.close(output_tree_file_handle)
         return t
 
     def estimate_model(char_matrix,
@@ -664,6 +666,7 @@ else:
                 except:
                     pass
         t = dendropy.Tree.get_from_path(output_tree_filepath, "nexus", taxon_set=char_matrix.taxon_set)
+        os.close(output_tree_file_handle)
         return t, results
 
     def prune_taxa_from_trees(trees, taxa, paup_path='paup'):
@@ -694,4 +697,5 @@ else:
         t = dendropy.TreeList.get_from_path(output_tree_filepath,
                 "nexus",
                 taxon_set=trees.taxon_set)
+        os.close(output_tree_file_handle)
         return t


### PR DESCRIPTION
I have code running hundreds of simulations that use `dendropy.interop.paup.estimate_tree`. Each time `tempfile.mkstemp` gets called the number of file handles open increases, eventually reaching the limit of allowed file handles.

The Paup module opens temporary files using mkstemp. According to [here](http://docs.python.org/2/library/tempfile.html#tempfile.mkstemp), the user of `tempfile.mkstemp` needs to delete the temporary file when done, which doesn't seem to be happening. 

I added `os.close(output_tree_file_handle)` wherever one of these temp files was created, which solved this problem.
