### PR TITLE
Fix Tree.resolve_polytomies() to not fail when a polytomy occurs a the root

### DIFF
--- a/dendropy/dataobject/tree.py
+++ b/dendropy/dataobject/tree.py
@@ -1321,7 +1321,7 @@ class Tree(TaxonSetLinked, iosys.Readable, iosys.Writeable):
         """
         Arbitrarily resolve polytomies using 0-length splits.
 
-        If `rng` is an object with a sample() method then the polytomy will be
+        If `rng` is an object with sample() and shuffle methods then the polytomy will be
             resolved by sequentially adding (generating all tree topologies
             equiprobably
             rng.sample() should behave like random.sample()
@@ -1337,10 +1337,11 @@ class Tree(TaxonSetLinked, iosys.Readable, iosys.Writeable):
             nc = len(children)
             if nc > 2:
                 if rng:
+					rng.shuffle(children)
                     to_attach = children[2:]
                     for child in to_attach:
                         node.remove_child(child)
-                    attachment_points = children[:2] + [node]
+                    attachment_points = children[:2]
                     while len(to_attach) > 0:
                         next_child = to_attach.pop()
                         next_sib = rng.sample(attachment_points, 1)[0]

--- a/dendropy/dataobject/tree.py
+++ b/dendropy/dataobject/tree.py
@@ -1337,7 +1337,7 @@ class Tree(TaxonSetLinked, iosys.Readable, iosys.Writeable):
             nc = len(children)
             if nc > 2:
                 if rng:
-					rng.shuffle(children)
+                    rng.shuffle(children)
                     to_attach = children[2:]
                     for child in to_attach:
                         node.remove_child(child)

--- a/dendropy/dataobject/tree.py
+++ b/dendropy/dataobject/tree.py
@@ -1321,7 +1321,7 @@ class Tree(TaxonSetLinked, iosys.Readable, iosys.Writeable):
         """
         Arbitrarily resolve polytomies using 0-length splits.
 
-        If `rng` is an object a sample() method then the polytomy will be
+        If `rng` is an object with a sample() method then the polytomy will be
             resolved by sequentially adding (generating all tree topologies
             equiprobably
             rng.sample() should behave like random.sample()

--- a/dendropy/dataobject/tree.py
+++ b/dendropy/dataobject/tree.py
@@ -1321,7 +1321,7 @@ class Tree(TaxonSetLinked, iosys.Readable, iosys.Writeable):
         """
         Arbitrarily resolve polytomies using 0-length splits.
 
-        If `rng` is an object with sample() and shuffle methods then the polytomy will be
+        If `rng` is an object with sample() and shuffle() methods then the polytomy will be
             resolved by sequentially adding (generating all tree topologies
             equiprobably
             rng.sample() should behave like random.sample()

--- a/dendropy/dataobject/tree.py
+++ b/dendropy/dataobject/tree.py
@@ -1321,7 +1321,7 @@ class Tree(TaxonSetLinked, iosys.Readable, iosys.Writeable):
         """
         Arbitrarily resolve polytomies using 0-length splits.
 
-        If `rng` is an object with sample() and shuffle() methods then the polytomy will be
+        If `rng` is an object a sample() method then the polytomy will be
             resolved by sequentially adding (generating all tree topologies
             equiprobably
             rng.sample() should behave like random.sample()
@@ -1337,7 +1337,7 @@ class Tree(TaxonSetLinked, iosys.Readable, iosys.Writeable):
             nc = len(children)
             if nc > 2:
                 if rng:
-                    rng.shuffle(children)
+                    children = rng.sample(children, nc)
                     to_attach = children[2:]
                     for child in to_attach:
                         node.remove_child(child)


### PR DESCRIPTION
I believe this is will preserve the past randomness while allowing polytomies to be resolved when they are at the root (e.g. star tree). I was trying to randomly perturb some trees using this method and it would fail when the root was chosen as the 'next_sib'. I could be wrong, but I believe shuffling the children as I did on line 1340 removes the need to include 'node' in attachment points.
