### PR TITLE
Add support for interleaved PHYLIP writing

### DIFF
--- a/dendropy/dataio/phylipwriter.py
+++ b/dendropy/dataio/phylipwriter.py
@@ -123,6 +123,7 @@ class PhylipWriter(ioservice.DataWriter):
                         stream.write("%s%s%s\n" % ( label.ljust(maxlen), spacer, str(seq_vec)))
                     else:
                         stream.write(str(seq_vec))
+                        stream.write('\n')
 
             position += self.max_line_length
     def get_taxon_label_map(self, taxon_namespace):

--- a/dendropy/dataio/phylipwriter.py
+++ b/dendropy/dataio/phylipwriter.py
@@ -126,6 +126,8 @@ class PhylipWriter(ioservice.DataWriter):
                         stream.write('\n')
 
             position += self.max_line_length
+            if position < n_sites:
+                stream.write('\n')
     def get_taxon_label_map(self, taxon_namespace):
         taxon_label_map = {}
         if self.strict:

--- a/dendropy/dataio/phylipwriter.py
+++ b/dendropy/dataio/phylipwriter.py
@@ -122,6 +122,7 @@ class PhylipWriter(ioservice.DataWriter):
                     if position == 0:
                         stream.write("%s%s%s\n" % ( label.ljust(maxlen), spacer, str(seq_vec)))
                     else:
+                        stream.write(' ')
                         stream.write(str(seq_vec))
                         stream.write('\n')
 

--- a/dendropy/dataio/phylipwriter.py
+++ b/dendropy/dataio/phylipwriter.py
@@ -114,7 +114,7 @@ class PhylipWriter(ioservice.DataWriter):
                 if taxon in char_matrix:
 
                     seq_subset = char_matrix[taxon].symbols_as_list()[position:position+self.max_line_length]
-                    seq_vec = ''.join([str(i) for i in seq_subset]])
+                    seq_vec = ''.join([str(i) for i in seq_subset])
                     
                 else:
                     seq_vec = ""


### PR DESCRIPTION
Some programs (e.g. FastTree) have a line length limitation for PHYLIP format, so alignments longer than a certain length (5000bp for FastTree) need to be given in interleaved format. This patch adds support for this feature.
