### PR TITLE
jplace style edge numbering

### DIFF
--- a/dendropy/dataio/newickreader.py
+++ b/dendropy/dataio/newickreader.py
@@ -13,7 +13,7 @@
 ##
 ##     Sukumaran, J. and M. T. Holder. 2010. DendroPy: a Python library
 ##     for phylogenetic computing. Bioinformatics 26: 1569-1571.
-##
+#
 ##############################################################################
 
 """
@@ -118,8 +118,7 @@ class NewickReader(ioservice.DataReader):
                     stream=stream)
 
     def __init__(self, **kwargs):
-        """
-        Keyword Arguments
+        """Keyword Arguments
         -----------------
         rooting : string, {['default-unrooted'], 'default-rooted', 'force-unrooted', 'force-rooted'}
             Specifies how trees in the data source should be intepreted with
@@ -181,10 +180,18 @@ class NewickReader(ioservice.DataReader):
         terminating_semicolon_required : boolean, default: |True|
             If |True| [default], then a tree statement that does not end in a
             semi-colon is an error. If |False|, then no error will be raised.
+        is_parse_jplace_tokens : boolean: |False|
+            If |True|, then accept edge numbering according to the jplace
+            format, as described in Matsen et. al. PLoS One, 2012
+            http://dx.doi.org/10.1371/journal.pone.0031009. An instance variable
+            edge_index is added to the returned tree, and an edge_number is
+            added to each edge. If False [default], encountering edge labels
+            raises a NewickReaderMalformedStatementError.
         ignore_unrecognized_keyword_arguments : boolean, default: |False|
             If |True|, then unsupported or unrecognized keyword arguments will
             not result in an error. Default is |False|: unsupported keyword
             arguments will result in an error.
+
         """
 
         # base
@@ -254,6 +261,7 @@ class NewickReader(ioservice.DataReader):
         self.suppress_leaf_node_taxa = kwargs.pop("suppress_external_node_taxa", False) # legacy (will be deprecated)
         self.suppress_leaf_node_taxa = kwargs.pop("suppress_leaf_node_taxa", self.suppress_leaf_node_taxa)
         self.terminating_semicolon_required = kwargs.pop("terminating_semicolon_required", True)
+        self.is_parse_jplace_tokens = kwargs.pop("is_parse_jplace_tokens", False)
         self.check_for_unused_keyword_arguments(kwargs)
 
         # per-tree book-keeping
@@ -622,11 +630,28 @@ class NewickReader(ioservice.DataReader):
                         line_num=nexus_tokenizer.token_line_num,
                         col_num=nexus_tokenizer.token_column_num,
                         stream=nexus_tokenizer.src)
+            elif self.is_parse_jplace_tokens and nexus_tokenizer.current_token == '{':
+                # Edge number from .jplace format
+                nexus_tokenizer.require_next_token()
+                edge_number = int(nexus_tokenizer.current_token)
+                edge = current_node.edge
+                edge.edge_number = edge_number
+                try:
+                    tree.edge_index.insert(edge_number, edge)
+                except AttributeError:
+                    tree.edge_index = []
+                    tree.edge_index.insert(edge_number, edge)
+                nexus_tokenizer.require_next_token() # for closing '}'
+                nexus_tokenizer.require_next_token()
             else: #267
                 # label
                 if label_parsed: #269
+                    msg = "Expecting ':'"
+                    if self.is_parse_jplace_tokens:
+                        msg += ", '{'"
+                    msg += ", ')', ',' or ';' after reading label but found '{}'".format(nexus_tokenizer.current_token)
                     raise NewickReader.NewickReaderMalformedStatementError(
-                            message="Expecting ':', ')', ',' or ';' after reading label but found '{}'".format(nexus_tokenizer.current_token),
+                            message=msg,
                             line_num=nexus_tokenizer.token_line_num,
                             col_num=nexus_tokenizer.token_column_num,
                             stream=nexus_tokenizer.src)


### PR DESCRIPTION
Hi there,

I was looking for a way to parse the jplace style newick-ish trees, described at
http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0031009

which involves adding an edge numbering to the format e.g.
```python
t1 = Tree.get(data='((A:.01{0}, B:.02{1})D:.04{3}, C:.05{4}){5};', schema='newick')

print(t1.edges()[0].edge_number)
# => 5

print([  [number,edge.length] for number,edge in enumerate(t1.edge_index)  ])
# => [[0, 0.01], [1, 0.02], [2, 0.04], [3, 0.05], [4, None]]
```
I've not included any test code or anything because I'm new here, and I wanted to see if I implemented it in a way you approve of first.

Thanks,
ben