### PR TITLE
Optimise popgenstat._count_differences()

### DIFF
--- a/dendropy/calculate/popgenstat.py
+++ b/dendropy/calculate/popgenstat.py
@@ -37,18 +37,26 @@ def _count_differences(char_sequences, state_alphabet, ignore_uncertain=True):
     sum_diff = 0.0
     mean_diff = 0.0
     sq_diff = 0.0
-    total_counted = 0
     comps = 0
+
+    #Check that all sequences are the same length
+    if len(set([len(seq) for seq in char_sequences])) != 1:
+        raise Exception("sequences of unequal length")
+
     if ignore_uncertain:
         attr = "fundamental_indexes_with_gaps_as_missing"
         states_to_ignore = set([state_alphabet.gap_state, state_alphabet.no_data_state])
     else:
         attr = "fundamental_indexes"
         states_to_ignore = set()
-    for vidx, i in enumerate(char_sequences[:-1]):
-        for j in char_sequences[vidx+1:]:
-            if len(i) != len(j):
-                raise Exception("sequences of unequal length")
+
+    reduced_char_sequences = []
+    for i, sequence in enumerate(char_sequences):
+        seq = [getattr(char, attr) for char in sequence]
+        reduced_char_sequences.append(seq)
+
+    for vidx, i in enumerate(reduced_char_sequences[:-1]):
+        for j in reduced_char_sequences[vidx+1:]:
             diff = 0
             counted = 0
             comps += 1
@@ -58,10 +66,7 @@ def _count_differences(char_sequences, state_alphabet, ignore_uncertain=True):
                 if c1 in states_to_ignore or c2 in states_to_ignore:
                     continue
                 counted += 1
-                total_counted += 1
-                f1 = getattr(c1, attr)
-                f2 = getattr(c2, attr)
-                if f1 != f2:
+                if c1 is not c2:
                     diff += 1
             sum_diff += float(diff)
             # If counted < 0, this means that there is sites between these sequences
@@ -418,5 +423,3 @@ def unfolded_site_frequency_spectrum(
         else:
             freqs[p] += 1
     return freqs
-
-

--- a/dendropy/calculate/popgenstat.py
+++ b/dendropy/calculate/popgenstat.py
@@ -51,7 +51,7 @@ def _count_differences(char_sequences, state_alphabet, ignore_uncertain=True):
         states_to_ignore = set()
 
     reduced_char_sequences = []
-    for i, sequence in enumerate(char_sequences):
+    for sequence in char_sequences:
         seq = [getattr(char, attr) for char in sequence]
         reduced_char_sequences.append(seq)
 


### PR DESCRIPTION
I've been using the Tajima's D method from the popgenstat module, and noticed that it is very slow to run on large numbers of sequences.

It seems a significant portion of this is down to the calculation of the number of pairwise differences. In particular, the calls to `getattr(char, attr)` that are happening within the nested loops are causing significant overhead. I've modified the method so that this `getattr()` is only performed once for each character in each sequence. I've also changed the actual check of inequality between characters to `c1 is not c2`, rather than `c1 != c2`, as this is also a lot faster (and we actually do want to check that the object reference is the same).

Regards,

Andrew Guy