### PR TITLE
Deep copy annotation

### DIFF
--- a/dendropy/datamodel/basemodel.py
+++ b/dendropy/datamodel/basemodel.py
@@ -976,7 +976,7 @@ class AnnotationSet(container.OrderedSet):
         try:
             o = self.__class__(target=memo[id(self.target)])
         except KeyError:
-            raise KeyError("deepcopy error: object id {} not found: {}".format((id(self.target), repr(self.target))))
+            raise KeyError("deepcopy error: object id {} not found: {}".format(id(self.target), repr(self.target)))
         memo[id(self)] = o
         for a in self:
             x = copy.deepcopy(a, memo)

--- a/dendropy/datamodel/basemodel.py
+++ b/dendropy/datamodel/basemodel.py
@@ -731,7 +731,8 @@ class Annotable(object):
                 if a2.is_attribute and a1._value[0] is other:
                     a2._value = (self, a1._value[1])
                 self.annotations.add(a2)
-            memo[id(other._annotations)] = self._annotations
+            if hasattr(self, "_annotations"):
+                memo[id(other._annotations)] = self._annotations
 
     # def __copy__(self):
     #     o = self.__class__.__new__(self.__class__)


### PR DESCRIPTION
Commit 59f55fb9ab09ac06e0bdbd7a30727d8758b75249 allows annotations to be modified more flexibly, and commit 2b59d9a0565e1c1e09b210c785544836ef6bef52 just fixes a typo.