### PR TITLE
faster pruning

### DIFF
--- a/dendropy/datamodel/treemodel.py
+++ b/dendropy/datamodel/treemodel.py
@@ -5301,6 +5301,7 @@ class Tree(
         Removes terminal nodes associated with Taxon objects given by the container
         ``taxa`` (which can be any iterable, including a TaxonNamespace object) from ``self``.
         """
+        taxa = set(taxa)
         nodes_to_remove = []
         for nd in self.postorder_node_iter():
             if (


### PR DESCRIPTION
I had to prune taxa of a very very large tree (around 1 million taxa), and dendropy was not scalable for the task. This simple modification helped me.

It originally needs 320s to prune 4421 taxa from a tree with 88434 taxa (http://files.opentreeoflife.org/trees/v3subtrees/chordata.tre.gz) on my PC, whereas the modified version needs 240s. Speed gain will be greater for bigger trees.

Here is code for the benchmark.


```
import dendropy
import random
import time

tree = dendropy.Tree.get(data=open('chordata.tre').read(), schema='newick')

tree_len = len(tree.taxon_namespace)
print('total taxa: %s' % tree_len)
labels_to_prune = random.sample([o.label for o in tree.taxon_namespace], int(tree_len/20))

print('pruning %s taxa' % len(labels_to_prune))

start = time.time()
tree.prune_taxa_with_labels(labels_to_prune)
print('time elapse: %s sec' % (time.time()-start))
```
