### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,14 @@ Or::
 If you do not have |pip|_ installed, you should *definitely* `install it <https://pip.pypa.io/en/latest/installing.html>`_ !
 Other ways of obtaining and installing DendroPy (e.g., by downloading the |dendropy_source_archive|_, or by cloning the `DendroPy Git repository <http://github.com/jeetsukumaran/DendroPy>`_), are discussed in detail in the ":doc:`/downloading`" section.
 
+If you are using the `conda package manager` <https://conda.io/docs/>, dendropy can be installed to your conda environment via pip. From within an Anaconda terminal, or a `Jupyter Notebook` <http://jupyter.org/>, type::
+
+    $ import pip
+    $ pip.main(['install', 'dendropy'])
+
+dendropy will now be available in your conda-managed environment.
+
+
 Documentation
 ==============
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,7 +59,7 @@ Or::
 If you do not have |pip|_ installed, you should *definitely* `install it <https://pip.pypa.io/en/latest/installing.html>`_ !
 Other ways of obtaining and installing DendroPy (e.g., by downloading the |dendropy_source_archive|_, or by cloning the `DendroPy Git repository <http://github.com/jeetsukumaran/DendroPy>`_), are discussed in detail in the ":doc:`/downloading`" section.
 
-If you are using the `conda package manager` <https://conda.io/docs/>, dendropy can be installed to your conda environment via pip. From within an Anaconda terminal, or a `Jupyter Notebook` <http://jupyter.org/>, type::
+If you are using the `conda package manager <https://conda.io/docs/>`_, dendropy can be installed to your conda environment via pip. From within an Anaconda terminal, or a `Jupyter Notebook <http://jupyter.org/>`_, type::
 
     $ import pip
     $ pip.main(['install', 'dendropy'])

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,12 +59,12 @@ Or::
 If you do not have |pip|_ installed, you should *definitely* `install it <https://pip.pypa.io/en/latest/installing.html>`_ !
 Other ways of obtaining and installing DendroPy (e.g., by downloading the |dendropy_source_archive|_, or by cloning the `DendroPy Git repository <http://github.com/jeetsukumaran/DendroPy>`_), are discussed in detail in the ":doc:`/downloading`" section.
 
-If you are using the `conda package manager <https://conda.io/docs/>`_, dendropy can be installed to your conda environment via pip. From within an Anaconda terminal, or a `Jupyter Notebook <http://jupyter.org/>`_, type::
+If you are using the `conda package manager <https://conda.io/docs/>`_, DendroPy can be installed to your conda environment via pip. From within an Anaconda terminal, or a `Jupyter Notebook <http://jupyter.org/>`_, type::
 
     $ import pip
     $ pip.main(['install', 'dendropy'])
 
-dendropy will now be available in your conda-managed environment.
+DendroPy will now be available in your conda-managed environment.
 
 
 Documentation


### PR DESCRIPTION
Instructions for installing dendropy to conda-managed environments. It's quite easy - you just import pip as a module in your Anaconda terminal or Jupyter notebook.