### PR TITLE
Use dictionary.items instead of iteritems for Python3 Compatibility

### DIFF
--- a/src/dendropy/datamodel/treemodel.py
+++ b/src/dendropy/datamodel/treemodel.py
@@ -6238,7 +6238,7 @@ class Tree(
             dot_nd = "n%d" % n
             out.write(' %s  [label="%s"];\n' % (dot_nd, label))
             nd_id_to_dot_nd[nd] = dot_nd
-        for nd, dot_nd in nd_id_to_dot_nd.iteritems():
+        for nd, dot_nd in nd_id_to_dot_nd.items():
             try:
                 e = nd.edge
                 par_dot_nd = nd_id_to_dot_nd[e.tail_node]


### PR DESCRIPTION
This enables Python3 compatibility, which has dropped the .iteritems method.

As far as I can tell, this is the only place in the library that iteritems remains—I grepped the rest of the source code, and while there are some hits in src/dendropy/utility/container.py, that seems to be implementing an iteritems method, rather than relying on its presence in a dictionary. 