### PR TITLE
Fixing bug in contained_coalescent_tree function.

### DIFF
--- a/src/dendropy/model/coalescent.py
+++ b/src/dendropy/model/coalescent.py
@@ -513,7 +513,7 @@ def contained_coalescent_tree(containing_tree,
         if edge.head_node.parent_node is None:
             if len(pop_node_genes[edge.head_node]) > 1:
                 final = coalesce_nodes(nodes=pop_node_genes[edge.head_node],
-                                            pop_size=default_pop_size,
+                                            pop_size=pop_size,
                                             period=None,
                                             rng=rng)
             else:


### PR DESCRIPTION
Fixing bug in dendropy.model.coalescent.contained_coalescent_tree.
`default_pop_size` was always being used for the root edge, even if a
different value was specified via an attribute of the root edge. This
commit fixes this by specifying the correct variable in the final call
to `coalesce_nodes`.