### PR TITLE
Bugfix: Tree mrca method does not account for internal unifurcation

### DIFF
--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -1569,6 +1569,10 @@ class Tree(
                     if cms == leafset_bitmask:
                         # curr_node has all of the 1's that bipartition has
                         if cm == leafset_bitmask:
+                            # step down internal unifurcations until first
+                            # multifurcation
+                            while curr_node.num_child_nodes() == 1:
+                                curr_node, = curr_node.child_nodes()
                             return curr_node
                         last_match = curr_node
                         nd_source = iter(curr_node.child_nodes())

--- a/tests/test_datamodel_tree_structure_and_iteration.py
+++ b/tests/test_datamodel_tree_structure_and_iteration.py
@@ -23,6 +23,7 @@ Tests basic Tree structure and iteration.
 
 import unittest
 import dendropy
+import itertools
 import os
 import sys
 sys.path.insert(0, os.path.dirname(__file__))
@@ -133,6 +134,35 @@ class TestTreeNodeFinders(curated_test_tree.CuratedTestTree, unittest.TestCase):
         tree, anodes, lnodes, inodes = self.get_tree()
         node = tree.find_node_with_label("zzz")
         self.assertIs(node, None)
+
+    def test_mrca(self):
+        tree, anodes, lnodes, inodes = self.get_tree()
+
+        # setup taxa
+        for nd in tree.leaf_node_iter():
+            nd.taxon = tree.taxon_namespace.new_taxon(nd.label)
+
+        # setting is_rooted necessary to precent dissappearance of node c
+        # when encoding bipartitions with collapse_unrooted_basal_bifurcation
+        # False
+        tree.is_rooted = True
+
+        # for each internal node as mrca, pick arbitrary leaf nodes
+        mrca_leaves_labels = [
+            ("a", ("l", "j")),
+            ("b", ("i", "k")),
+            ("c", ("m", "n")),
+            ("e", ("k", "j")),
+            ("f", ("p", "n")),
+            ("g", ("l", "m")),
+            ("h", ("p", "o")),
+        ]
+
+        # no internal unifurcations
+        for true_mrca_label, leaf_labels in mrca_leaves_labels:
+            for taxon_labels in itertools.permutations(leaf_labels, 2):
+                result_mrca_node = tree.mrca(taxon_labels=taxon_labels)
+                self.assertEqual(true_mrca_label, result_mrca_node.label)
 
 class TestTreeIterators(curated_test_tree.CuratedTestTree, unittest.TestCase):
 


### PR DESCRIPTION
Added tests for existing `Tree.mrca()` method, fixed bug, added regression tests to `Tree.mrca()` method for bug.  

minimum working bug:
```python3
from dendropy import Tree

# set up tree with an internal unifurcation
tree = Tree.get(
    data="((tip1,tip2)true_mrca)root;",
    schema="newick",
)
tree.print_plot(
    plot_metric="level",
    show_internal_node_labels=True,
)

# bug: "root" node detected as mrca instead of "true_mrca"
mrca_node = tree.mrca(taxon_labels=["tip1", "tip2"])
print(mrca_node.label)
```
