### PR TITLE
Fix unexpected rooting side effects of `Tree.mrca()`

### DIFF
--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -1550,7 +1550,10 @@ class Tree(
         if start_node.edge.bipartition.leafset_bitmask == 0 or not kwargs.get(
             "is_bipartitions_updated", True
         ):
-            self.encode_bipartitions(suppress_unifurcations=False)
+            self.encode_bipartitions(
+                suppress_unifurcations=False,
+                collapse_unrooted_basal_bifurcation=False,
+            )
 
         if (
             start_node.edge.bipartition.leafset_bitmask & leafset_bitmask


### PR DESCRIPTION
Sets `collapse_unrooted_basal_bifurcation=False` in call to `Tree.encode_bipartitions` inside `Tree.mrca`. Closes #152.

I ran tests locally and it didn't cause any test failures. (I had 10 failing tests both before and after making the change). 