### PR TITLE
Pass rng in evolve_states

### DIFF
--- a/src/dendropy/model/discrete.py
+++ b/src/dendropy/model/discrete.py
@@ -132,7 +132,10 @@ class DiscreteCharacterEvolver(object):
                 seq_model  = getattr(edge, self.seq_model_attr, None) or self.seq_model
                 length = getattr(edge, self.edge_length_attr)
                 mutation_rate = getattr(edge, self.edge_rate_attr, None) or self.mutation_rate
-                seq_list.append(seq_model.simulate_descendant_states(par_seq, length, mutation_rate))
+                seq_list.append(seq_model.simulate_descendant_states(par_seq,
+                                                                     length,
+                                                                     mutation_rate,
+                                                                     rng=rng))
             else:
                 # no tail node: root
                 n_prev_seq = len(seq_list)

--- a/src/dendropy/model/discrete.py
+++ b/src/dendropy/model/discrete.py
@@ -567,7 +567,9 @@ def hky85_chars(
     seq_model = Hky85(
             kappa=kappa,
             base_freqs=base_freqs,
-            state_alphabet=state_alphabet)
+            state_alphabet=state_alphabet,
+            rng=rng,
+    )
     return simulate_discrete_chars(seq_len=seq_len,
                                tree_model=tree_model,
                                seq_model=seq_model,

--- a/tests/test_discrete.py
+++ b/tests/test_discrete.py
@@ -1,0 +1,60 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+##############################################################################
+##  DendroPy Phylogenetic Computing Library.
+##
+##  Copyright 2010-2015 Jeet Sukumaran and Mark T. Holder.
+##  All rights reserved.
+##
+##  See "LICENSE.rst" for terms and conditions of usage.
+##
+##  If you use this work or any portion thereof in published work,
+##  please cite it as:
+##
+##     Sukumaran, J. and M. T. Holder. 2010. DendroPy: a Python library
+##     for phylogenetic computing. Bioinformatics 26: 1569-1571.
+##
+##############################################################################
+
+"""
+Discrete character tests.
+"""
+
+import random
+import unittest
+from dendropy.model import discrete
+from dendropy.simulate import treesim
+
+class DiscreteCharacterEvolverTest(unittest.TestCase):
+
+    def test_rng_param(self):
+        """Test determinism from rng param.
+
+        Regression test for #170.
+        """
+        tree = treesim.birth_death_tree(
+            birth_rate=1.0,
+            death_rate=0.5,
+            num_extant_tips=4,
+            rng=random.Random(100)
+        )
+        assert (
+            discrete.hky85_chars(10, tree, rng=random.Random(1)).as_string(
+                schema="nexml",
+            )
+            == discrete.hky85_chars(10, tree, rng=random.Random(1)).as_string(
+                schema="nexml",
+            )
+        )
+        assert (
+            discrete.hky85_chars(10, tree, rng=random.Random(1)).as_string(
+                schema="nexml",
+            )
+            != discrete.hky85_chars(10, tree, rng=random.Random(2)).as_string(
+                schema="nexml",
+            )
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This change makes the `evolve_states` method of `DiscreteCharacterEvolver` pass its `rng` parameter to `seq_model.simulate_descendant_states`.

Before the change, this code results in an `AssertionError`:

```python
from random import Random
from dendropy.model import discrete
from dendropy.simulate import treesim

def test_chars(t, rng):
    return sorted(str(s) for s in discrete.hky85_chars(10, t, rng=rng).values())

if __name__ == "__main__":
    tree = treesim.birth_death_tree(
        birth_rate=1.0,
        death_rate=0.5,
        num_extant_tips=4,
        rng=Random(100)
    )
    t1 = test_chars(tree, Random(100))
    t2 = test_chars(tree, Random(100))
    assert t1 == t2
```

After this change, the assertion succeeds.