### PR TITLE
Pin ruff linter version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install ruff==0.0.292
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with ruff
         run: |


### PR DESCRIPTION
CLI --format option broken by the Ruff 0.1.0, pin to [v0.0.292](https://github.com/astral-sh/ruff/releases/tag/v0.0.292)