### PR TITLE
Option to give leaf nodes in polytomies a default order in Tree.ladderize.

### DIFF
--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -3107,15 +3107,6 @@ class Tree(
         If ``default_order`` is |True| then leaf nodes get sorted by taxon
         labels when they are in polytomies.
         """
-
-        if default_order:
-            order = {
-                name: index
-                for index, name in enumerate(
-                    sorted(leaf.taxon.label for leaf in self.leaf_node_iter())
-                )
-            }
-
         node_desc_counts = {}
         for nd in self.postorder_node_iter():
             if len(nd._child_nodes) == 0:
@@ -3129,7 +3120,11 @@ class Tree(
                 nd._child_nodes.sort(
                     key=lambda n: (
                         node_desc_counts[n],
-                        order.get(n.taxon.label, len(order)) if default_order else 0
+                        (
+                            n.taxon.label
+                            if default_order and hasattr(n, "taxon") and hasattr(n.taxon, "label")
+                            else 0
+                        )
                     ),
                     reverse=not ascending,
                 )

--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -3119,7 +3119,7 @@ class Tree(
         def dorder(node):  # -> int
             if default_order:
                 try:
-                    return order.index(node.taxon.label)
+                    return order[node.taxon.label]
                 except ValueError:
                     return len(order)
             else:

--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -3116,15 +3116,6 @@ class Tree(
                 )
             }
 
-        def dorder(node):  # -> int
-            if default_order:
-                try:
-                    return order[node.taxon.label]
-                except ValueError:
-                    return len(order)
-            else:
-                return 0
-
         node_desc_counts = {}
         for nd in self.postorder_node_iter():
             if len(nd._child_nodes) == 0:
@@ -3136,7 +3127,10 @@ class Tree(
                 total += len(nd._child_nodes)
                 node_desc_counts[nd] = total
                 nd._child_nodes.sort(
-                    key=lambda n: (node_desc_counts[n], dorder(n)),
+                    key=lambda n: (
+                        node_desc_counts[n],
+                        order.get(n.taxon.label, len(order)) if default_order else 0
+                    ),
                     reverse=not ascending,
                 )
 

--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -3109,13 +3109,18 @@ class Tree(
         """
 
         if default_order:
-            order = tuple(sorted(leaf.taxon.label for leaf in self.leaf_node_iter()))
+            order = {
+                name: index
+                for index, name in enumerate(
+                    sorted(leaf.taxon.label for leaf in self.leaf_node_iter())
+                )
+            }
 
         def dorder(node) -> int:
             if default_order:
                 try:
                     return order.index(node.taxon.label)
-                except:
+                except ValueError:
                     return len(order)
             else:
                 return 0

--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -3116,7 +3116,7 @@ class Tree(
                 )
             }
 
-        def dorder(node) -> int:
+        def dorder(node):  # -> int
             if default_order:
                 try:
                     return order.index(node.taxon.label)


### PR DESCRIPTION
I added this option to reduce unnecessary cross overs in tangle plots of trees that have polytomies.