### PR TITLE
Remove preserve_underscores as an argument in docstring example usages of datamodel.basemodel.Serializable.write

### DIFF
--- a/src/dendropy/datamodel/basemodel.py
+++ b/src/dendropy/datamodel/basemodel.py
@@ -576,13 +576,12 @@ class Serializable(object):
 
         ::
 
-                d.write(path="path/to/file.dat",
-                        schema="nexus",
-                        preserve_underscores=True)
-                f = open("path/to/file.dat")
-                d.write(file=f,
-                        schema="nexus",
-                        preserve_underscores=True)
+                # Using a file path:
+                d.write(path="path/to/file.dat", schema="nexus")
+
+                # Using an open file:
+                with open("path/to/file.dat", "w") as f:
+                    d.write(file=f, schema="nexus")
 
         """
         return Serializable._write_to(self, **kwargs)


### PR DESCRIPTION
I don't know if there are more instances of this that should also be changed. But passing `preserve_underscores` to `write` (as opposed to using when reading) in version 5.0.1 gets me a `TypeError`:

```
TypeError: Unrecognized or unsupported arguments: {'preserve_underscores': True}
```
