### PR TITLE
Improved docstring for src/dendropy/datamodel/treemodel/_tree.py/reroot_at_edge

### DIFF
--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -2590,7 +2590,7 @@ class Tree(
         the tree on the new node.
         ``length1`` will be assigned to the new (sub-)edge leading
         to the original parent of the original edge. ``length2`` will be
-        assigned to new (sub-)edge leading to the original child of the original edge.
+        assigned to the new (sub-)edge leading to the original child of the original edge.
         If ``update_bipartitions`` is True, then the edges' ``bipartition`` and the tree's
         ``bipartition_encoding`` attributes will be updated.
         If the *old* root of the tree had an outdegree of 2, then after this

--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -2589,8 +2589,9 @@ class Tree(
         Takes an internal edge, ``edge``, adds a new node to it, and then roots
         the tree on the new node.
         ``length1`` will be assigned to the new (sub-)edge leading
-        to the original parent of the original edge. ``length2`` will be
-        assigned to the new (sub-)edge leading to the original child of the original edge.
+        to the original parent of the original edge.
+        ``length2`` will be assigned to the new (sub-)edge leading to the original
+        child of the original edge.
         If ``update_bipartitions`` is True, then the edges' ``bipartition`` and the tree's
         ``bipartition_encoding`` attributes will be updated.
         If the *old* root of the tree had an outdegree of 2, then after this

--- a/src/dendropy/datamodel/treemodel/_tree.py
+++ b/src/dendropy/datamodel/treemodel/_tree.py
@@ -2588,9 +2588,9 @@ class Tree(
         """
         Takes an internal edge, ``edge``, adds a new node to it, and then roots
         the tree on the new node.
-        ``length1`` and ``length2`` will be assigned to the new (sub-)edge leading
-        to the old parent of the original edge, while ``length2`` will be
-        assigned to the old child of the original edge.
+        ``length1`` will be assigned to the new (sub-)edge leading
+        to the original parent of the original edge. ``length2`` will be
+        assigned to new (sub-)edge leading to the original child of the original edge.
         If ``update_bipartitions`` is True, then the edges' ``bipartition`` and the tree's
         ``bipartition_encoding`` attributes will be updated.
         If the *old* root of the tree had an outdegree of 2, then after this


### PR DESCRIPTION
The current docstring says

```
``length1`` and ``length2`` will be assigned to the new (sub-)edge leading
        to the old parent of the original edge, while ``length2`` will be
        assigned to the old child of the original edge.
```

which is clearly(?) wrong, since `length2` is mentioned twice.