### PR TITLE
fix: add missing self to reindex_subcomponent_taxa

### DIFF
--- a/src/dendropy/datamodel/taxonmodel.py
+++ b/src/dendropy/datamodel/taxonmodel.py
@@ -407,7 +407,7 @@ class TaxonNamespaceAssociated(object):
         self.reindex_subcomponent_taxa()
         return self.taxon_namespace
 
-    def reindex_subcomponent_taxa():
+    def reindex_subcomponent_taxa(self):
         """
         DEPRECATED: Use :meth:`reconstruct_taxon_namespace()` instead.
         Derived classes should override this to ensure that their various

--- a/src/dendropy/datamodel/treecollectionmodel.py
+++ b/src/dendropy/datamodel/treecollectionmodel.py
@@ -1019,7 +1019,7 @@ class TreeList(
             tree.poll_taxa(taxa)
         return taxa
 
-    def reindex_subcomponent_taxa():
+    def reindex_subcomponent_taxa(self):
         raise NotImplementedError()
 
    ##############################################################################

--- a/tests/unittests/test_datamodel_tree_list.py
+++ b/tests/unittests/test_datamodel_tree_list.py
@@ -25,6 +25,7 @@ import unittest
 import collections
 import dendropy
 import random
+import warnings
 import os
 import sys
 sys.path.insert(0, os.path.dirname(__file__))
@@ -1010,6 +1011,22 @@ class TestTreeListMigrateAndReconstructTaxonNamespace(
                 unify_taxa_by_label=True,
                 case_sensitive_label_mapping=False,
                 original_tns=original_tns)
+
+    def test_reindex_subcomponent_taxa_raises_not_implemented(self):
+        # Regression: the stub was defined without a `self` parameter, so
+        # calling it as an instance method raised TypeError instead of the
+        # intended NotImplementedError.
+        with self.assertRaises(NotImplementedError):
+            self.tree_list.reindex_subcomponent_taxa()
+
+    def test_reindex_taxa_raises_not_implemented(self):
+        # `reindex_taxa` is deprecated and delegates to
+        # `reindex_subcomponent_taxa`; it should surface NotImplementedError
+        # rather than a TypeError about positional argument counts.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with self.assertRaises(NotImplementedError):
+                self.tree_list.reindex_taxa()
 
 class TestTreeListAppend(
         curated_test_tree.CuratedTestTree,


### PR DESCRIPTION
`TaxonNamespaceAssociated.reindex_subcomponent_taxa` is defined without `self`:

```python
def reindex_subcomponent_taxa():
    raise NotImplementedError()
```

but it's called as `self.reindex_subcomponent_taxa()` from `reindex_taxa()`. Any class that relies on the base stub (instead of overriding it) hits a `TypeError` the moment `reindex_taxa()` runs, instead of the intended `NotImplementedError`.

`TreeList` is one such class: it doesn't override `reindex_subcomponent_taxa`... wait, it does, but with the identical bug in `treecollectionmodel.py`:

```python
def reindex_subcomponent_taxa():
    raise NotImplementedError()
```

Repro before the fix:

```python
import dendropy
tl = dendropy.TreeList.get(data='(A,(B,C));', schema='newick')
tl.reindex_taxa()
# TypeError: TreeList.reindex_subcomponent_taxa() takes 0 positional arguments but 1 was given
```

`Tree.reindex_taxa()` and `CharacterMatrix.reindex_taxa()` work fine since those subclasses override `reindex_subcomponent_taxa(self)` correctly with `self` already. This PR adds the missing `self` to the two remaining definitions so the call succeeds and, for classes without a real implementation, raises `NotImplementedError` as designed rather than crashing with a confusing `TypeError`.

Ran the taxon and tree-collection test suites plus the full unit suite locally: 884 passed, 4 pre-existing failures unrelated to this change (they need the external `paup` binary, which isn't installed in my environment).