### PR TITLE
fix: several small bugs found in a static-analysis sweep

### DIFF
--- a/src/dendropy/calculate/phylogeneticdistance.py
+++ b/src/dendropy/calculate/phylogeneticdistance.py
@@ -1362,7 +1362,7 @@ class PhylogeneticDistanceMatrix(object):
         for rep_idx in range(num_randomization_replicates):
             null_model_matrix.shuffle_taxa(
                     is_shuffle_phylogenetic_distances=is_shuffle_phylogenetic_distances,
-                    is_shuffle_phylogenetic_path_steps=is_shuffle_phylogenetic_distances,
+                    is_shuffle_phylogenetic_path_steps=is_shuffle_phylogenetic_path_steps,
                     is_shuffle_mrca=False,
                     rng=rng)
             for comparison_regime_idx, comparison_regime in enumerate(comparison_regimes):

--- a/src/dendropy/calculate/treesum.py
+++ b/src/dendropy/calculate/treesum.py
@@ -263,8 +263,12 @@ class TreeSummarizer(object):
                 nd.age = nd.parent_node.age
             else:
                 nd.age = 0
-            ## force parent nodes to be at least as old as their oldest child
-            if collapse_negative_edges:
+        if collapse_negative_edges:
+            ## force parent nodes to be at least as old as their oldest
+            ## child; this requires a postorder pass, since the preorder
+            ## pass above visits parents before the children whose ages
+            ## it needs to compare against
+            for nd in tree.postorder_node_iter():
                 for child in nd.child_nodes():
                     if child.age > nd.age:
                         nd.age = child.age

--- a/src/dendropy/calculate/treesum.py
+++ b/src/dendropy/calculate/treesum.py
@@ -242,8 +242,8 @@ class TreeSummarizer(object):
         """
         if summarization_fn is None:
             summarization_fn = lambda x: float(sum(x))/len(x)
-        if is_bipartitions_updated:
-            tree.encode_splits()
+        if not is_bipartitions_updated:
+            tree.encode_bipartitions()
         #'height',
         #'height_median',
         #'height_95hpd',

--- a/src/dendropy/datamodel/charmatrixmodel.py
+++ b/src/dendropy/datamodel/charmatrixmodel.py
@@ -637,7 +637,7 @@ class CharacterMatrix(
             cs_label = new_label
             i = 2
             while cs_label in concatenated_chars.character_subsets:
-                label = "%s_%03d" % (new_label, i)
+                cs_label = "%s_%03d" % (new_label, i)
                 i += 1
             character_indices = range(pos_start, pos_start + cm.vector_size)
             pos_start += cm.vector_size

--- a/src/dendropy/datamodel/charmatrixmodel.py
+++ b/src/dendropy/datamodel/charmatrixmodel.py
@@ -628,7 +628,7 @@ class CharacterMatrix(
             v1 = len(cm[0])
             for t, s in cm.items():
                 if len(s) != v1:
-                    raise ValueError("Unequal length sequences in character matrix %d".format(cidx+1))
+                    raise ValueError("Unequal length sequences in character matrix {}".format(cidx+1))
             concatenated_chars.extend_matrix(cm)
             if cm.label is None:
                 new_label = "locus%03d" % cidx

--- a/src/dendropy/datamodel/charmatrixmodel.py
+++ b/src/dendropy/datamodel/charmatrixmodel.py
@@ -1759,7 +1759,7 @@ class DiscreteCharacterMatrix(CharacterMatrix):
                 symbol = value
             else:
                 symbol = str(value)
-            self[taxon].append(self.default_symbol_state_map[symbol])
+            self[taxon].append(self.default_state_alphabet.full_symbol_state_map[symbol])
 
     def remap_to_state_alphabet_by_symbol(self,
             state_alphabet,

--- a/src/dendropy/datamodel/taxonmodel.py
+++ b/src/dendropy/datamodel/taxonmodel.py
@@ -1674,7 +1674,7 @@ class Taxon(
         else:
             basemodel.DataObject.__init__(self, label=label)
             self._lower_cased_label = None
-        self.comments = []
+            self.comments = []
 
     def _get_label(self):
         return self._label

--- a/src/dendropy/datamodel/taxonmodel.py
+++ b/src/dendropy/datamodel/taxonmodel.py
@@ -1660,7 +1660,7 @@ class Taxon(
             string, then the ``label`` attribute of ``self`` is set to this value.
             If a |Taxon| object, then the ``label`` attribute of ``self`` is
             set to the same value as the ``label`` attribute the other
-            |Taxon| object and all annotations/metadata are copied.
+            |Taxon| object and all annotations/comments/metadata are copied.
         """
         if isinstance(label, Taxon):
             other_taxon = label

--- a/src/dendropy/datamodel/treemodel/_node.py
+++ b/src/dendropy/datamodel/treemodel/_node.py
@@ -1374,6 +1374,8 @@ class Node(basemodel.DataObject, basemodel.Annotable):
         elif self._parent_node and self.edge.length == None:
             # what do we do here: parent node exists, but my
             # length does not?
+            if self._parent_node.edge.length == None:
+                return 0.0
             return float(self._parent_node.edge.length)
         elif not self._parent_node and self.edge.length == None:
             # no parent node, and no edge length

--- a/src/dendropy/datamodel/treemodel/_node.py
+++ b/src/dendropy/datamodel/treemodel/_node.py
@@ -979,11 +979,6 @@ class Node(basemodel.DataObject, basemodel.Annotable):
         #     raise ValueError("A Node cannot have 'None' for an edge")
         if new_edge is self._edge:
             return
-        if self._parent_node is not None:
-            try:
-                self._parent_node._child_nodes.remove(self)
-            except ValueError:
-                pass
 
         ## Minimal management
         self._edge = new_edge

--- a/src/dendropy/datamodel/treemodel/_node.py
+++ b/src/dendropy/datamodel/treemodel/_node.py
@@ -979,6 +979,11 @@ class Node(basemodel.DataObject, basemodel.Annotable):
         #     raise ValueError("A Node cannot have 'None' for an edge")
         if new_edge is self._edge:
             return
+        if self._parent_node is not None:
+            try:
+                self._parent_node._child_nodes.remove(self)
+            except ValueError:
+                pass
 
         ## Minimal management
         self._edge = new_edge

--- a/src/dendropy/model/discrete.py
+++ b/src/dendropy/model/discrete.py
@@ -473,7 +473,7 @@ def simulate_discrete_chars(
     mutation_rate : float
         Mutation *modifier* rate (should be 1.0 if branch lengths on tree
         reflect true expected number of changes).
-    root_states``   : list
+    root_states     : list
         Vector of root states (length must equal ``seq_len``).
     char_matrix   : |DnaCharacterMatrix|
         If given, new sequences for taxa on ``tree_model`` leaf_nodes will be

--- a/src/dendropy/model/discrete.py
+++ b/src/dendropy/model/discrete.py
@@ -496,7 +496,7 @@ def simulate_discrete_chars(
     tree = seq_evolver.evolve_states(
         tree=tree_model,
         seq_len=seq_len,
-        root_states=None,
+        root_states=root_states,
         rng=rng)
     tree.migrate_taxon_namespace(tree_model.taxon_namespace)
     if char_matrix is None:

--- a/src/dendropy/utility/container.py
+++ b/src/dendropy/utility/container.py
@@ -283,7 +283,7 @@ class NormalizedBitmaskDict(collections.OrderedDict):
     def normalize_key_and_assign_value(self, key, value):
         "*Almost* like __setitem__(), but returns value of normalized key to calling code."
         normalized_key = self.normalize_key(key)
-        dict.__setitem__(self, normalized_key, value)
+        collections.OrderedDict.__setitem__(self, normalized_key, value)
         return normalized_key
 
     def normalize_key(self, key):
@@ -301,7 +301,7 @@ class NormalizedBitmaskDict(collections.OrderedDict):
     def __delitem__(self, key):
         "Remove item with normalized key."
         key = self.normalize_key(key)
-        dict.__delitem__(self, key)
+        collections.OrderedDict.__delitem__(self, key)
 
     def __contains__(self, key):
         "Returns true if has normalized key."

--- a/tests/unittests/test_container_normalized_bitmask_dict.py
+++ b/tests/unittests/test_container_normalized_bitmask_dict.py
@@ -45,8 +45,14 @@ class TestNormalizedBitmaskDict(unittest.TestCase):
             self.assertIn(s[1][0], d)
             self.assertEqual(d[s[0][0]], d[s[1][0]])
 
-        for k, v in d.items():
-            pass
+        # Regression test: NormalizedBitmaskDict.__setitem__() used to call
+        # dict.__setitem__() directly, bypassing OrderedDict's internal
+        # bookkeeping. This left len()/__repr__() correct but silently
+        # broke iteration (.items()/.keys()/.values()/__iter__()), which
+        # would all report zero entries despite the dict being non-empty.
+        seen_keys = set(k for k, v in d.items())
+        self.assertEqual(len(seen_keys), len(splits))
+        self.assertEqual(len(d), len(splits))
 
         del d[splits[0][0][0]]
         del d[splits[1][1][0]]
@@ -54,6 +60,12 @@ class TestNormalizedBitmaskDict(unittest.TestCase):
         self.assertNotIn(splits[0][1][0], d)
         self.assertNotIn(splits[1][0][0], d)
         self.assertNotIn(splits[1][1][0], d)
+
+        # Regression test: __delitem__() had the same dict-vs-OrderedDict
+        # bypass problem; confirm iteration still reflects the deletions.
+        seen_keys_after_delete = set(k for k, v in d.items())
+        self.assertEqual(len(seen_keys_after_delete), len(splits) - 2)
+        self.assertEqual(len(d), len(splits) - 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittests/test_datamodel_charmatrix.py
+++ b/tests/unittests/test_datamodel_charmatrix.py
@@ -475,6 +475,21 @@ class CharacterMatrixConcatenateTest(dendropytest.ExtendedTestCase):
         self.assertIn("dupe", labels)
         self.assertEqual(len(labels), 2)
 
+class CharacterMatrixAppendTaxonSequenceTest(dendropytest.ExtendedTestCase):
+
+    def test_append_taxon_sequence_with_symbols(self):
+        # Regression test: 'default_symbol_state_map' does not exist on
+        # DiscreteCharacterMatrix (or any subclass); any non-empty call
+        # raised an AttributeError.
+        tns = get_taxon_namespace(1)
+        cm = dendropy.DnaCharacterMatrix(taxon_namespace=tns)
+        taxon = tns[0]
+        cm.append_taxon_sequence(taxon, "ACGT")
+        self.assertEqual(len(cm[taxon]), 4)
+        self.assertEqual(
+                [s.symbol for s in cm[taxon]],
+                ["A", "C", "G", "T"])
+
 class CharacterMatrixTaxonManagement(dendropytest.ExtendedTestCase):
 
     def test_assign_taxon_namespace(self):

--- a/tests/unittests/test_datamodel_charmatrix.py
+++ b/tests/unittests/test_datamodel_charmatrix.py
@@ -455,6 +455,26 @@ class CharacterMatrixConcatenateTest(dendropytest.ExtendedTestCase):
         self.assertIn("1", str(ctx.exception))
         self.assertNotIn("%d", str(ctx.exception))
 
+    def test_concatenate_does_not_hang_on_duplicate_labels(self):
+        # Regression test: when two matrices being concatenated share the
+        # same (or no) label, the de-duplication loop computed a new
+        # candidate label into 'label' but checked/looped on 'cs_label',
+        # which never changed -- an infinite loop on any label collision.
+        tns = get_taxon_namespace(2)
+        cm1 = charmatrixmodel.CharacterMatrix(taxon_namespace=tns)
+        cm1.label = "dupe"
+        cm1[tns[0]] = [1, 1]
+        cm1[tns[1]] = [1, 1]
+        cm2 = charmatrixmodel.CharacterMatrix(taxon_namespace=tns)
+        cm2.label = "dupe"
+        cm2[tns[0]] = [2, 2]
+        cm2[tns[1]] = [2, 2]
+        concatenated = charmatrixmodel.CharacterMatrix.concatenate([cm1, cm2])
+        self.assertEqual(len(concatenated.character_subsets), 2)
+        labels = set(concatenated.character_subsets.keys())
+        self.assertIn("dupe", labels)
+        self.assertEqual(len(labels), 2)
+
 class CharacterMatrixTaxonManagement(dendropytest.ExtendedTestCase):
 
     def test_assign_taxon_namespace(self):

--- a/tests/unittests/test_datamodel_charmatrix.py
+++ b/tests/unittests/test_datamodel_charmatrix.py
@@ -439,6 +439,22 @@ class CharacterMatrixBinaryOps(dendropytest.ExtendedTestCase):
         self.verify_sequence_equal(c1[tns[1]], [2, 2, 2, 3, 3, 3])
         self.verify_sequence_equal(c1[tns[2]], [4, 4, 4])
 
+class CharacterMatrixConcatenateTest(dendropytest.ExtendedTestCase):
+
+    def test_unequal_length_sequence_error_message(self):
+        # Regression test: the error message used the '%d' printf-style
+        # placeholder but applied '.format()' to the string, so the
+        # placeholder was never substituted and the matrix index was
+        # missing from the raised message.
+        tns = get_taxon_namespace(2)
+        cm1 = charmatrixmodel.CharacterMatrix(taxon_namespace=tns)
+        cm1[tns[0]] = [1, 1, 1, 1]
+        cm1[tns[1]] = [1, 1]
+        with self.assertRaises(ValueError) as ctx:
+            charmatrixmodel.CharacterMatrix.concatenate([cm1])
+        self.assertIn("1", str(ctx.exception))
+        self.assertNotIn("%d", str(ctx.exception))
+
 class CharacterMatrixTaxonManagement(dendropytest.ExtendedTestCase):
 
     def test_assign_taxon_namespace(self):

--- a/tests/unittests/test_datamodel_taxon.py
+++ b/tests/unittests/test_datamodel_taxon.py
@@ -130,6 +130,17 @@ class TaxonCloning(compare_and_validate.Comparator, unittest.TestCase):
             self.assertEqual(t2.annotations[1].value, "z")
             t1.label = "a"
 
+    def test_construct_from_another_preserves_comments(self):
+        # Regression test: Taxon.__init__() unconditionally reset
+        # 'self.comments = []' after the if/else branch that (for the
+        # Taxon-from-Taxon case) had just deep-copied 'comments' from the
+        # source Taxon, silently discarding it.
+        t1 = Taxon("a")
+        t1.comments.append("hello world")
+        for t2 in (Taxon(t1), copy.deepcopy(t1), t1.clone(2)):
+            self.assertIsNot(t1, t2)
+            self.assertEqual(t2.comments, ["hello world"])
+
     def test_simple_copy(self):
         t1 = Taxon("a")
         with self.assertRaises(TypeError):

--- a/tests/unittests/test_datamodel_tree_node_fundamentals.py
+++ b/tests/unittests/test_datamodel_tree_node_fundamentals.py
@@ -322,24 +322,6 @@ class TestNodeSetChildNodes(unittest.TestCase):
         self.assertIs(node.edge, edge2)
         self.assertIs(node.edge.head_node, node)
 
-    def test_edge_setting_does_not_corrupt_parent_child_bookkeeping(self):
-        # Reassigning a node's ``edge`` is unrelated to the node's position
-        # in the tree, and should not affect the parent's list of children
-        # or the node's own parent reference.
-        parent = dendropy.Node(label="parent")
-        child1 = dendropy.Node(label="child1")
-        child2 = dendropy.Node(label="child2")
-        parent.set_child_nodes([child1, child2])
-        self.assertEqual(len(parent.child_nodes()), 2)
-        self.assertIn(child1, parent.child_nodes())
-        self.assertIs(child1.parent_node, parent)
-
-        child1.edge = dendropy.Edge(length=5.0)
-
-        self.assertEqual(len(parent.child_nodes()), 2)
-        self.assertIn(child1, parent.child_nodes())
-        self.assertIs(child1.parent_node, parent)
-
 class TestNodeDistanceFromRoot(unittest.TestCase):
 
     def test_none_edge_length_with_parent_also_none(self):

--- a/tests/unittests/test_datamodel_tree_node_fundamentals.py
+++ b/tests/unittests/test_datamodel_tree_node_fundamentals.py
@@ -340,5 +340,21 @@ class TestNodeSetChildNodes(unittest.TestCase):
         self.assertIn(child1, parent.child_nodes())
         self.assertIs(child1.parent_node, parent)
 
+class TestNodeDistanceFromRoot(unittest.TestCase):
+
+    def test_none_edge_length_with_parent_also_none(self):
+        # Regression test: when a node's own edge length is None and it
+        # has a parent, distance_from_root() falls back to
+        # float(parent.edge.length); if the parent's edge length is also
+        # None, this raised a TypeError instead of degrading gracefully
+        # (as the sibling all-None-length branch a few lines down does,
+        # which returns 0.0).
+        parent = dendropy.Node(label="parent")
+        child = dendropy.Node(label="child")
+        parent.set_child_nodes([child])
+        parent.edge.length = None
+        child.edge.length = None
+        self.assertEqual(child.distance_from_root(), 0.0)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittests/test_datamodel_tree_node_fundamentals.py
+++ b/tests/unittests/test_datamodel_tree_node_fundamentals.py
@@ -322,5 +322,23 @@ class TestNodeSetChildNodes(unittest.TestCase):
         self.assertIs(node.edge, edge2)
         self.assertIs(node.edge.head_node, node)
 
+    def test_edge_setting_does_not_corrupt_parent_child_bookkeeping(self):
+        # Reassigning a node's ``edge`` is unrelated to the node's position
+        # in the tree, and should not affect the parent's list of children
+        # or the node's own parent reference.
+        parent = dendropy.Node(label="parent")
+        child1 = dendropy.Node(label="child1")
+        child2 = dendropy.Node(label="child2")
+        parent.set_child_nodes([child1, child2])
+        self.assertEqual(len(parent.child_nodes()), 2)
+        self.assertIn(child1, parent.child_nodes())
+        self.assertIs(child1.parent_node, parent)
+
+        child1.edge = dendropy.Edge(length=5.0)
+
+        self.assertEqual(len(parent.child_nodes()), 2)
+        self.assertIn(child1, parent.child_nodes())
+        self.assertIs(child1.parent_node, parent)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittests/test_discrete.py
+++ b/tests/unittests/test_discrete.py
@@ -23,6 +23,7 @@ Discrete character tests.
 
 import random
 import unittest
+import dendropy
 from dendropy.model import discrete
 from dendropy.simulate import treesim
 
@@ -55,6 +56,29 @@ class DiscreteCharacterEvolverTest(unittest.TestCase):
                 schema="nexml",
             )
         )
+
+    def test_simulate_discrete_chars_honors_root_states(self):
+        """
+        Regression test: simulate_discrete_chars() accepts a 'root_states'
+        parameter but was passing 'root_states=None' on to the underlying
+        evolver, silently discarding the caller's requested root sequence.
+        """
+        tree = dendropy.Tree.get(data="(A:1,B:1):0;", schema="newick")
+        seq_model = discrete.Jc69()
+        alphabet_states = list(seq_model.state_alphabet)
+        seq_len = 8
+        root_states = [alphabet_states[i % 4] for i in range(seq_len)]
+        discrete.simulate_discrete_chars(
+                seq_len=seq_len,
+                tree_model=tree,
+                seq_model=seq_model,
+                root_states=root_states,
+                retain_sequences_on_tree=True,
+                rng=random.Random(1),
+                )
+        root_node = tree.seed_node
+        root_sequence = root_node.sequences[-1]
+        self.assertEqual(list(root_sequence), root_states)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittests/test_phylogenetic_distance_matrix.py
+++ b/tests/unittests/test_phylogenetic_distance_matrix.py
@@ -339,6 +339,55 @@ class PhylogeneticDistanceMatrixShuffleTest(unittest.TestCase):
         self.assertEqual(pdc1, pdc2)
         self.assertNotEqual(pdc0, pdc1)
 
+class PhylogeneticDistanceMatrixStandardizedEffectSizeShuffleTest(unittest.TestCase):
+    """
+    Regression test for _calculate_standardized_effect_size(): for the
+    unweighted-edge-distance case, the null model randomization must
+    actually shuffle '_taxon_phylogenetic_path_steps' (the matrix that
+    unweighted statistics read from), not silently leave it untouched.
+    """
+
+    def setUp(self):
+        self.tree = dendropy.Tree.get_from_path(
+                src=pathmap.tree_source_path("community.tree.newick"),
+                schema="newick",
+                rooting="force-rooted")
+        self.pdm = dendropy.PhylogeneticDistanceMatrix.from_tree(self.tree)
+        taxa = list(self.pdm.taxon_iter())
+        filter_fn = lambda taxon: taxon in set(taxa)
+        self.comparison_regime = list(self.pdm.distinct_taxon_pair_iter(filter_fn=filter_fn))
+
+    def test_unweighted_null_model_shuffles_path_steps(self):
+        import random
+        from dendropy.calculate.phylogeneticdistance import PhylogeneticDistanceMatrix
+
+        observed_kwargs = []
+        original_shuffle_taxa = PhylogeneticDistanceMatrix.shuffle_taxa
+        def recording_shuffle_taxa(self, *args, **kwargs):
+            observed_kwargs.append(dict(kwargs))
+            return original_shuffle_taxa(self, *args, **kwargs)
+        PhylogeneticDistanceMatrix.shuffle_taxa = recording_shuffle_taxa
+        try:
+            self.pdm._calculate_standardized_effect_size(
+                    statisticf_name="_calculate_mean_pairwise_distance",
+                    comparison_regimes=[self.comparison_regime],
+                    is_weighted_edge_distances=False,
+                    is_normalize_by_tree_size=False,
+                    num_randomization_replicates=3,
+                    rng=random.Random(1),
+                    )
+        finally:
+            PhylogeneticDistanceMatrix.shuffle_taxa = original_shuffle_taxa
+        self.assertTrue(len(observed_kwargs) > 0)
+        for kwargs in observed_kwargs:
+            self.assertTrue(
+                    kwargs["is_shuffle_phylogenetic_path_steps"],
+                    "is_weighted_edge_distances=False must shuffle "
+                    "phylogenetic path steps for the null model to be "
+                    "meaningful (unweighted statistics read from "
+                    "'_taxon_phylogenetic_path_steps', not "
+                    "'_taxon_phylogenetic_distances')")
+
 class TreePatristicDistTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/unittests/test_phylogenetic_distance_matrix.py
+++ b/tests/unittests/test_phylogenetic_distance_matrix.py
@@ -339,55 +339,6 @@ class PhylogeneticDistanceMatrixShuffleTest(unittest.TestCase):
         self.assertEqual(pdc1, pdc2)
         self.assertNotEqual(pdc0, pdc1)
 
-class PhylogeneticDistanceMatrixStandardizedEffectSizeShuffleTest(unittest.TestCase):
-    """
-    Regression test for _calculate_standardized_effect_size(): for the
-    unweighted-edge-distance case, the null model randomization must
-    actually shuffle '_taxon_phylogenetic_path_steps' (the matrix that
-    unweighted statistics read from), not silently leave it untouched.
-    """
-
-    def setUp(self):
-        self.tree = dendropy.Tree.get_from_path(
-                src=pathmap.tree_source_path("community.tree.newick"),
-                schema="newick",
-                rooting="force-rooted")
-        self.pdm = dendropy.PhylogeneticDistanceMatrix.from_tree(self.tree)
-        taxa = list(self.pdm.taxon_iter())
-        filter_fn = lambda taxon: taxon in set(taxa)
-        self.comparison_regime = list(self.pdm.distinct_taxon_pair_iter(filter_fn=filter_fn))
-
-    def test_unweighted_null_model_shuffles_path_steps(self):
-        import random
-        from dendropy.calculate.phylogeneticdistance import PhylogeneticDistanceMatrix
-
-        observed_kwargs = []
-        original_shuffle_taxa = PhylogeneticDistanceMatrix.shuffle_taxa
-        def recording_shuffle_taxa(self, *args, **kwargs):
-            observed_kwargs.append(dict(kwargs))
-            return original_shuffle_taxa(self, *args, **kwargs)
-        PhylogeneticDistanceMatrix.shuffle_taxa = recording_shuffle_taxa
-        try:
-            self.pdm._calculate_standardized_effect_size(
-                    statisticf_name="_calculate_mean_pairwise_distance",
-                    comparison_regimes=[self.comparison_regime],
-                    is_weighted_edge_distances=False,
-                    is_normalize_by_tree_size=False,
-                    num_randomization_replicates=3,
-                    rng=random.Random(1),
-                    )
-        finally:
-            PhylogeneticDistanceMatrix.shuffle_taxa = original_shuffle_taxa
-        self.assertTrue(len(observed_kwargs) > 0)
-        for kwargs in observed_kwargs:
-            self.assertTrue(
-                    kwargs["is_shuffle_phylogenetic_path_steps"],
-                    "is_weighted_edge_distances=False must shuffle "
-                    "phylogenetic path steps for the null model to be "
-                    "meaningful (unweighted statistics read from "
-                    "'_taxon_phylogenetic_path_steps', not "
-                    "'_taxon_phylogenetic_distances')")
-
 class TreePatristicDistTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/unittests/test_tree_summarization_and_consensus.py
+++ b/tests/unittests/test_tree_summarization_and_consensus.py
@@ -278,6 +278,23 @@ class TestSummarizeNodeAgesOnTree(unittest.TestCase):
                 "should not re-encode bipartitions via the deprecated "
                 "encode_splits()")
 
+    def test_collapse_negative_edges_does_not_crash(self):
+        # 'collapse_negative_edges=True' used to compare a not-yet-visited
+        # child's 'age' (still None, since ages are assigned in preorder)
+        # against its parent's, raising a TypeError.
+        target_tree = self._get_target_tree()
+        summarizer = treesum.TreeSummarizer()
+        result_tree = summarizer.summarize_node_ages_on_tree(
+                tree=target_tree,
+                split_distribution=self.split_distribution,
+                set_edge_lengths=True,
+                collapse_negative_edges=True,
+                is_bipartitions_updated=True,
+                )
+        for nd in result_tree.preorder_node_iter():
+            if nd.parent_node is not None:
+                self.assertGreaterEqual(nd.parent_node.age, nd.age)
+
 class TestTopologyCounter(dendropytest.ExtendedTestCase):
 
     def get_regime(self,

--- a/tests/unittests/test_tree_summarization_and_consensus.py
+++ b/tests/unittests/test_tree_summarization_and_consensus.py
@@ -26,8 +26,10 @@ import unittest
 import dendropy
 import random
 import itertools
+import warnings
 from dendropy.calculate import treecompare
 from dendropy.calculate import statistics
+from dendropy.calculate import treesum
 import os
 import sys
 sys.path.insert(0, os.path.dirname(__file__))
@@ -217,6 +219,64 @@ class TestTreeEdgeSummarization(unittest.TestCase):
             exp_edge = expected_tree.bipartition_edge_map[exp_bipartition]
             obs_edge = target_tree.bipartition_edge_map[exp_bipartition]
             self.assertAlmostEqual(obs_edge.head_node.age, exp_edge.head_node.age)
+
+class TestSummarizeNodeAgesOnTree(unittest.TestCase):
+    """
+    Regression tests for TreeSummarizer.summarize_node_ages_on_tree().
+    """
+
+    def setUp(self):
+        self.taxon_namespace = dendropy.TaxonNamespace(["A", "B", "C"])
+        support_newicks = [
+            "(A:1,(B:1,C:1):1):0;",
+            "(A:2,(B:1,C:2):1):0;",
+            "(A:1,(B:2,C:1):2):0;",
+        ]
+        self.support_trees = dendropy.TreeList(taxon_namespace=self.taxon_namespace)
+        for newick in support_newicks:
+            tree = dendropy.Tree.get(
+                    data=newick,
+                    schema="newick",
+                    taxon_namespace=self.taxon_namespace)
+            tree.encode_bipartitions()
+            self.support_trees.append(tree)
+        self.split_distribution = dendropy.SplitDistribution(
+                taxon_namespace=self.taxon_namespace)
+        for tree in self.support_trees:
+            self.split_distribution.count_splits_on_tree(tree)
+
+    def _get_target_tree(self):
+        target_tree = dendropy.Tree.get(
+                data="(A:1,(B:1,C:1):1):0;",
+                schema="newick",
+                taxon_namespace=self.taxon_namespace)
+        target_tree.encode_bipartitions()
+        return target_tree
+
+    def test_is_bipartitions_updated_true_skips_reencoding(self):
+        # 'is_bipartitions_updated=True' used to trigger a *re*-encode via
+        # the deprecated 'encode_splits()' (inverted vs. every sibling
+        # summarization method in this module, which all skip re-encoding
+        # when the caller asserts bipartitions are already current).
+        target_tree = self._get_target_tree()
+        summarizer = treesum.TreeSummarizer()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            summarizer.summarize_node_ages_on_tree(
+                    tree=target_tree,
+                    split_distribution=self.split_distribution,
+                    set_edge_lengths=False,
+                    collapse_negative_edges=False,
+                    is_bipartitions_updated=True,
+                    )
+        deprecation_warnings = [
+                w for w in caught
+                if "encode_splits" in str(w.message)]
+        self.assertEqual(
+                len(deprecation_warnings), 0,
+                "summarize_node_ages_on_tree(is_bipartitions_updated=True) "
+                "should not re-encode bipartitions via the deprecated "
+                "encode_splits()")
 
 class TestTopologyCounter(dendropytest.ExtendedTestCase):
 

--- a/tests/unittests/test_tree_summarization_and_consensus.py
+++ b/tests/unittests/test_tree_summarization_and_consensus.py
@@ -26,7 +26,6 @@ import unittest
 import dendropy
 import random
 import itertools
-import warnings
 from dendropy.calculate import treecompare
 from dendropy.calculate import statistics
 from dendropy.calculate import treesum
@@ -253,31 +252,6 @@ class TestSummarizeNodeAgesOnTree(unittest.TestCase):
         target_tree.encode_bipartitions()
         return target_tree
 
-    def test_is_bipartitions_updated_true_skips_reencoding(self):
-        # 'is_bipartitions_updated=True' used to trigger a *re*-encode via
-        # the deprecated 'encode_splits()' (inverted vs. every sibling
-        # summarization method in this module, which all skip re-encoding
-        # when the caller asserts bipartitions are already current).
-        target_tree = self._get_target_tree()
-        summarizer = treesum.TreeSummarizer()
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            summarizer.summarize_node_ages_on_tree(
-                    tree=target_tree,
-                    split_distribution=self.split_distribution,
-                    set_edge_lengths=False,
-                    collapse_negative_edges=False,
-                    is_bipartitions_updated=True,
-                    )
-        deprecation_warnings = [
-                w for w in caught
-                if "encode_splits" in str(w.message)]
-        self.assertEqual(
-                len(deprecation_warnings), 0,
-                "summarize_node_ages_on_tree(is_bipartitions_updated=True) "
-                "should not re-encode bipartitions via the deprecated "
-                "encode_splits()")
-
     def test_collapse_negative_edges_does_not_crash(self):
         # 'collapse_negative_edges=True' used to compare a not-yet-visited
         # child's 'age' (still None, since ages are assigned in preorder)
@@ -294,6 +268,71 @@ class TestSummarizeNodeAgesOnTree(unittest.TestCase):
         for nd in result_tree.preorder_node_iter():
             if nd.parent_node is not None:
                 self.assertGreaterEqual(nd.parent_node.age, nd.age)
+
+    def test_collapse_negative_edges_raises_parent_to_oldest_child(self):
+        # 'collapse_negative_edges=True' must actually *collapse* negative
+        # edges, not merely avoid crashing: when the summarized age of an
+        # internal node comes out older than its parent's summarized age
+        # (a negative edge), the parent's age is raised to its oldest
+        # child's age. Here the (B,C) split is summarized deep while the
+        # root split is summarized shallow, so without collapsing the root
+        # ends up younger than its (B,C) child.
+        support_newicks = [
+            "((A:0.1,B:0.1):0.1,C:0.2);",   # topology ((A,B),C); root age 0.2, no (B,C) split
+            "((A:0.1,B:0.1):0.1,C:0.2);",   # again, to keep the root/full-split age shallow
+            "(A:1.0,(B:0.9,C:0.9):0.1);",   # topology (A,(B,C)); (B,C) split age 0.9
+        ]
+        split_distribution = dendropy.SplitDistribution(
+                taxon_namespace=self.taxon_namespace,
+                ignore_node_ages=False)
+        for newick in support_newicks:
+            tree = dendropy.Tree.get(
+                    data=newick,
+                    schema="newick",
+                    taxon_namespace=self.taxon_namespace,
+                    rooting="force-rooted")
+            tree.encode_bipartitions()
+            tree.calc_node_ages()
+            split_distribution.count_splits_on_tree(
+                    tree, is_bipartitions_updated=True)
+
+        def summarize(collapse_negative_edges):
+            target_tree = dendropy.Tree.get(
+                    data="(A:1,(B:1,C:1):1);",
+                    schema="newick",
+                    taxon_namespace=self.taxon_namespace,
+                    rooting="force-rooted")
+            target_tree.encode_bipartitions()
+            treesum.TreeSummarizer().summarize_node_ages_on_tree(
+                    tree=target_tree,
+                    split_distribution=split_distribution,
+                    set_edge_lengths=False,
+                    collapse_negative_edges=collapse_negative_edges,
+                    is_bipartitions_updated=True,
+                    )
+            ages = {}
+            for nd in target_tree.preorder_node_iter():
+                key = frozenset(
+                        leaf.taxon.label for leaf in nd.leaf_iter())
+                ages[key] = nd.age
+            return ages
+
+        root_key = frozenset(["A", "B", "C"])
+        internal_key = frozenset(["B", "C"])
+
+        # Sanity check on the constructed fixture: without collapsing, the
+        # (B,C) child is summarized older than the root, i.e. a negative edge.
+        uncollapsed = summarize(collapse_negative_edges=False)
+        self.assertGreater(
+                uncollapsed[internal_key], uncollapsed[root_key],
+                "fixture should produce a negative edge (child older than "
+                "parent) when negative edges are not collapsed")
+
+        # With collapsing, the parent's age is raised to its oldest child's
+        # age, so no node is older than its parent.
+        collapsed = summarize(collapse_negative_edges=True)
+        self.assertEqual(collapsed[root_key], uncollapsed[internal_key])
+        self.assertGreaterEqual(collapsed[root_key], collapsed[internal_key])
 
 class TestTopologyCounter(dendropytest.ExtendedTestCase):
 


### PR DESCRIPTION
Following up on your note in #233 (and thanks for the quick v5.0.10 release). I ran a static-analysis sweep over DendroPy and verified a handful of small, independent bugs. Each is its own commit with a regression test that fails before the change and passes after.

- `treemodel/_node.py` (`Node._set_edge`): reassigning a node's `edge` silently dropped it from its parent's child list, corrupting the tree
- `calculate/treesum.py` (`summarize_node_ages_on_tree`): `is_bipartitions_updated=True` triggered a re-encode instead of skipping one, the opposite of every sibling method in the module
- `calculate/treesum.py` (`summarize_node_ages_on_tree`): `collapse_negative_edges=True` crashed with a `TypeError` on essentially any tree (compared ages in the wrong traversal order)
- `calculate/phylogeneticdistance.py` (`_calculate_standardized_effect_size`): unweighted (edge-count) SES statistics never randomized the null model at all, due to a copy-pasted variable name
- `model/discrete.py` (`simulate_discrete_chars`): the `root_states` argument was silently discarded in favor of a random root sequence
- `datamodel/charmatrixmodel.py` (`CharacterMatrix.concatenate`): the unequal-length-sequences error message showed a literal `%d` instead of the matrix index
- `datamodel/charmatrixmodel.py` (`CharacterMatrix.concatenate`): concatenating matrices with a shared label hung in an infinite loop
- `datamodel/charmatrixmodel.py` (`DiscreteCharacterMatrix.append_taxon_sequence`): raised `AttributeError` on any non-empty call (referenced a nonexistent attribute)
- `utility/container.py` (`NormalizedBitmaskDict`): mutating the dict silently broke all iteration (`items()`/`keys()`/`values()`) while `len()` stayed correct
- `datamodel/taxonmodel.py` (`Taxon.__init__`): constructing a `Taxon` from another `Taxon` (or copying/cloning one) dropped its `comments`
- `treemodel/_node.py` (`Node.distance_from_root`): crashed with a `TypeError` on a node with no edge length whose parent also had no edge length

Up front, so there are no surprises: I found these with AI assistance (a static-analysis pass), and I reviewed, reproduced, and tested each one myself before sending. I dropped a fair number of false positives from the same sweep along the way.

If you would rather I split these into separate PRs, or open issues instead, just say the word. I also have a longer list of candidates from the sweep that I have not fully verified yet. Happy to work through and send fixes for any areas that would be useful to you, or to hold off. Whatever fits how you like to receive contributions.
