### PR TITLE
fix: reassigning `Node.edge` no longer detaches the node from its parent

### DIFF
--- a/src/dendropy/datamodel/treemodel/_node.py
+++ b/src/dendropy/datamodel/treemodel/_node.py
@@ -979,11 +979,6 @@ class Node(basemodel.DataObject, basemodel.Annotable):
         #     raise ValueError("A Node cannot have 'None' for an edge")
         if new_edge is self._edge:
             return
-        if self._parent_node is not None:
-            try:
-                self._parent_node._child_nodes.remove(self)
-            except ValueError:
-                pass
 
         ## Minimal management
         self._edge = new_edge

--- a/tests/unittests/test_datamodel_tree_node_fundamentals.py
+++ b/tests/unittests/test_datamodel_tree_node_fundamentals.py
@@ -322,6 +322,25 @@ class TestNodeSetChildNodes(unittest.TestCase):
         self.assertIs(node.edge, edge2)
         self.assertIs(node.edge.head_node, node)
 
+    def test_edge_setting_does_not_corrupt_parent_child_bookkeeping(self):
+        # Reassigning a node's ``edge`` is unrelated to the node's position
+        # in the tree, and should not affect the parent's list of children
+        # or the node's own parent reference.
+        parent = dendropy.Node(label="parent")
+        child1 = dendropy.Node(label="child1")
+        child2 = dendropy.Node(label="child2")
+        parent.set_child_nodes([child1, child2])
+        self.assertEqual(len(parent.child_nodes()), 2)
+        self.assertIn(child1, parent.child_nodes())
+        self.assertIs(child1.parent_node, parent)
+
+        child1.edge = dendropy.Edge(length=5.0)
+
+        self.assertEqual(len(parent.child_nodes()), 2)
+        self.assertIn(child1, parent.child_nodes())
+        self.assertIs(child1.parent_node, parent)
+
+
 class TestNodeDistanceFromRoot(unittest.TestCase):
 
     def test_none_edge_length_with_parent_also_none(self):


### PR DESCRIPTION
Split out of #234 at @mmore500's request, so the parent/children bookkeeping change can be discussed on its own.

### What it changes

`Node._set_edge()` (the setter behind `node.edge = new_edge`) removed the node from its parent's `_child_nodes` list as a side effect of swapping in a new `Edge`:

```python
if self._parent_node is not None:
    try:
        self._parent_node._child_nodes.remove(self)
    except ValueError:
        pass
```

This patch removes those lines. A node's `tail_node` is derived from `head_node._parent_node`, not stored on the edge, so swapping the edge object has no bearing on where the node sits in the tree. As written, `node.edge = new_edge` silently dropped the node from its parent's children while `node.parent_node` still pointed at the old parent, leaving the tree in an inconsistent state.

The change is covered by a regression test (`test_edge_setting_does_not_corrupt_parent_child_bookkeeping`) asserting that after reassigning a child's `edge`, the parent still lists the child and the child still points back at the parent.

### Why it's split from #234

#234 is a batch of small, independent static-analysis fixes. This one touches live tree-mutation semantics rather than a self-contained bug, so it warrants its own review thread. The rest of #234 (including the unrelated `distance_from_root()` None-parent fix in the same file) stays there.

### Open question from @mmore500

Should `_parent_node` also be reset when the edge is reassigned? This PR only stops the node from being removed from the parent's `_child_nodes` list, it does not touch `_parent_node`. If the intended semantics of reassigning an edge are "detach this node from its current parent entirely," then both sides of the link (`_parent_node` and the parent's `_child_nodes`) should be cleared together, rather than the current half-and-half. Happy to adjust in whichever direction you prefer.
